### PR TITLE
Add Node/Next.js ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
 # Global ignores
 frontend/tmp/
+
+# Node dependencies
+node_modules/
+
+# Next.js build output
+.next/
+
+# Environment variables
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*


### PR DESCRIPTION
## Summary
- avoid committing common Node/Next.js build artifacts by ignoring them

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68448d9e30b0832291bd484863fb527b