### PR TITLE
Fix firebase initialization for Next.js build

### DIFF
--- a/frontend/src/lib/firebase.js
+++ b/frontend/src/lib/firebase.js
@@ -1,7 +1,7 @@
 // src/lib/firebase.js
 
 import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
+import { getAuth as fbGetAuth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,7 +13,18 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
+let firebaseApp;
+let auth;
 
-export { auth };
+export function getFirebaseAuth() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  if (!firebaseApp) {
+    firebaseApp = initializeApp(firebaseConfig);
+    auth = fbGetAuth(firebaseApp);
+  }
+
+  return auth;
+}

--- a/frontend/src/pages/app.js
+++ b/frontend/src/pages/app.js
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { auth } from '../lib/firebase';
+import { getFirebaseAuth } from '../lib/firebase';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 
 export default function AppPage() {
@@ -16,6 +16,7 @@ export default function AppPage() {
   const router = useRouter();
 
   useEffect(() => {
+    const auth = getFirebaseAuth();
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
       if (currentUser) {
         setUser(currentUser);
@@ -31,6 +32,7 @@ export default function AppPage() {
   }, [router]);
 
   const handleLogout = async () => {
+    const auth = getFirebaseAuth();
     await signOut(auth);
     router.push('/login');
   };

--- a/frontend/src/pages/login.js
+++ b/frontend/src/pages/login.js
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { auth } from '../lib/firebase';
+import { getFirebaseAuth } from '../lib/firebase';
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
 
 export default function Login() {
@@ -17,10 +17,12 @@ export default function Login() {
     setLoading(true);
     setError(null);
     try {
+      const auth = getFirebaseAuth();
       await signInWithEmailAndPassword(auth, email, password);
       router.push('/app');
     } catch (err) {
       try {
+        const auth = getFirebaseAuth();
         await createUserWithEmailAndPassword(auth, email, password);
         router.push('/app');
       } catch (signupErr) {


### PR DESCRIPTION
## Summary
- avoid calling Firebase client methods during `next build`
- export `getFirebaseAuth` helper
- update pages to initialize auth only in the browser

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68448d9b1c888322ad2afd535af4e040