### PR TITLE
Include uid in Stripe sessions

### DIFF
--- a/backend/api/create-checkout-session.js
+++ b/backend/api/create-checkout-session.js
@@ -5,6 +5,7 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 export default async function handler(req, res) {
   if (req.method === 'POST') {
     try {
+      const { uid } = req.body;
       const session = await stripe.checkout.sessions.create({
         payment_method_types: ['card'],
         line_items: [
@@ -20,8 +21,9 @@ export default async function handler(req, res) {
           },
         ],
         mode: 'payment',
-        success_url: `${req.headers.origin}/success?session_id={CHECKOUT_SESSION_ID}`,
+        success_url: `${req.headers.origin}/success?uid=${uid}`,
         cancel_url: `${req.headers.origin}/cancel`,
+        metadata: { uid },
       });
 
       res.status(200).json({ sessionId: session.id });

--- a/frontend/components/CheckoutButton.js
+++ b/frontend/components/CheckoutButton.js
@@ -2,10 +2,12 @@ import { loadStripe } from '@stripe/stripe-js';
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
 
-const CheckoutButton = () => {
+const CheckoutButton = ({ uid }) => {
   const handleClick = async () => {
     const res = await fetch('/api/create-checkout-session', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uid }),
     });
     const data = await res.json();
     const stripe = await stripePromise;


### PR DESCRIPTION
## Summary
- pass `uid` along to Stripe from the Express API
- accept `uid` in the checkout button used by the Express backend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844db4d15608322bd87b141fdb08682