### PR TITLE
Fix credit assignment for new and purchasing users

### DIFF
--- a/frontend/src/pages/api/credits.js
+++ b/frontend/src/pages/api/credits.js
@@ -20,7 +20,8 @@ export default async function handler(req, res) {
     const userSnap = await userRef.get();
 
     if (!userSnap.exists) {
-      return res.status(200).json({ credits: 0, freeUsesLeft: 0 });
+      await userRef.set({ credits: 0, freeUsesLeft: 3 });
+      return res.status(200).json({ credits: 0, freeUsesLeft: 3 });
     }
 
     const data = userSnap.data();

--- a/frontend/src/pages/success.js
+++ b/frontend/src/pages/success.js
@@ -5,6 +5,7 @@ export default function SuccessPage() {
   const router = useRouter();
 
   useEffect(() => {
+    if (!router.isReady) return;
     const { uid } = router.query;
 
     if (uid) {
@@ -22,7 +23,7 @@ export default function SuccessPage() {
           router.push('/app');
         });
     }
-  }, [router]);
+  }, [router.isReady, router.query.uid]);
 
   return (
     <div style={{ color: 'white', backgroundColor: '#0d1117', height: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>


### PR DESCRIPTION
## Summary
- initialize Firestore user record with 3 free uses on first credit query
- ensure credit-user API call runs after checkout by waiting for router to be ready

## Testing
- `npm run build` *(fails: Firebase auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68452eef6f748322880426ff799bb036