### PR TITLE
Centralize firebase admin

### DIFF
--- a/frontend/src/lib/firebaseAdmin.js
+++ b/frontend/src/lib/firebaseAdmin.js
@@ -1,0 +1,12 @@
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
+
+const app = !getApps().length
+  ? initializeApp({ credential: cert(serviceAccount) })
+  : getApps()[0];
+
+const db = getFirestore(app);
+
+export { db };

--- a/frontend/src/pages/api/credit-user.js
+++ b/frontend/src/pages/api/credit-user.js
@@ -1,13 +1,4 @@
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
-
-const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
-
-if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount) });
-}
-
-const db = getFirestore();
+import { db } from '../../lib/firebaseAdmin';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/frontend/src/pages/api/credits.js
+++ b/frontend/src/pages/api/credits.js
@@ -1,13 +1,4 @@
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
-
-const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
-
-if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount) });
-}
-
-const db = getFirestore();
+import { db } from '../../lib/firebaseAdmin';
 
 export default async function handler(req, res) {
   const { uid } = req.query;

--- a/frontend/src/pages/api/webhook.js
+++ b/frontend/src/pages/api/webhook.js
@@ -1,15 +1,8 @@
 import { buffer } from 'micro';
 import Stripe from 'stripe';
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
+import { db } from '../../lib/firebaseAdmin';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
-
-const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
-if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount) });
-}
-const db = getFirestore();
 
 export const config = {
   api: {


### PR DESCRIPTION
## Summary
- reuse a single Firebase Admin instance via new helper
- update credits.js, credit-user.js and webhook.js to import the helper

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479f24aca88322a2d35ca9833d98b4