### PR TITLE
Fix firebase-admin import path

### DIFF
--- a/shared/firebaseAdmin.js
+++ b/shared/firebaseAdmin.js
@@ -1,5 +1,4 @@
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
+import admin from 'firebase-admin';
 
 const key = process.env.FIREBASE_SERVICE_ACCOUNT_KEY;
 if (!key) {
@@ -13,11 +12,13 @@ try {
   throw new Error('FIREBASE_SERVICE_ACCOUNT_KEY contains invalid JSON');
 }
 
-const app = getApps().length
-  ? getApps()[0]
-  : initializeApp({ credential: cert(serviceAccount) });
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+  });
+}
 
-const db = getFirestore(app);
+const db = admin.firestore();
 
 export { db };
 


### PR DESCRIPTION
## Summary
- use `firebase-admin` root import in shared Firebase helper

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in frontend *(fails: Missing script)*
- `npm test` in backend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847a38a5a608322a9d03cf162d332e2