### PR TITLE
Fix userRef scoping for history uploads

### DIFF
--- a/frontend/src/pages/api/predictions.js
+++ b/frontend/src/pages/api/predictions.js
@@ -45,11 +45,11 @@ export default async function handler(req, res) {
     const costCharged = parseFloat((durationSeconds * RATE_PER_SECOND).toFixed(2));
 
     if (prediction.status === 'succeeded' && Array.isArray(prediction.output) && prediction.output[0]) {
+      const userRef = db.collection('users').doc(uid);
       let updatedCredits = 0;
       let updatedFreeUsesLeft = 0;
 
       try {
-        const userRef = db.collection('users').doc(uid);
         const snap = await userRef.get();
 
         if (!snap.exists) {


### PR DESCRIPTION
## Summary
- ensure `userRef` is defined outside the credit update block
- use the same reference when updating history

## Testing
- `node -e "require('./frontend/src/pages/api/predictions.js');"` *(fails: Cannot find package 'replicate')*

------
https://chatgpt.com/codex/tasks/task_e_6859c6a8791c8322abd63f3b2e9fc569