### PR TITLE
Add history page and profile button

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ Railway will automatically install dependencies and deploy the application.
 
 ## History Feature
 
-When an image is processed, the result is uploaded to Cloudinary and the URL is saved in a `history` subcollection under the user's Firestore document. Only the three most recent images are kept. You can retrieve them via the `/api/history` endpoint and they are displayed on the app page for easy download.
+When an image is processed, the result is uploaded to Cloudinary and the URL is saved in a `history` subcollection under the user's Firestore document. Only the three most recent images are kept. You can retrieve them via the `/api/history` endpoint. A new **Images History** button on the profile page opens a dedicated view where these images can be downloaded.
 

--- a/frontend/src/pages/api/predictions.js
+++ b/frontend/src/pages/api/predictions.js
@@ -45,11 +45,11 @@ export default async function handler(req, res) {
     const costCharged = parseFloat((durationSeconds * RATE_PER_SECOND).toFixed(2));
 
     if (prediction.status === 'succeeded' && Array.isArray(prediction.output) && prediction.output[0]) {
+      const userRef = db.collection('users').doc(uid);
       let updatedCredits = 0;
       let updatedFreeUsesLeft = 0;
 
       try {
-        const userRef = db.collection('users').doc(uid);
         const snap = await userRef.get();
 
         if (!snap.exists) {

--- a/frontend/src/pages/app.js
+++ b/frontend/src/pages/app.js
@@ -151,6 +151,20 @@ export default function AppPage() {
         <button onClick={handleRecharge} style={{ background: '#10b981', color: 'white', padding: '0.5rem 1rem', borderRadius: '6px', border: 'none', marginBottom: '1rem', cursor: 'pointer' }}>
           Buy Credits
         </button>
+        <button
+          onClick={() => router.push('/history')}
+          style={{
+            background: 'linear-gradient(to right, #10b981, #3b82f6)',
+            color: 'white',
+            padding: '0.5rem 1rem',
+            borderRadius: '6px',
+            border: 'none',
+            marginBottom: '1rem',
+            cursor: 'pointer'
+          }}
+        >
+          Images History
+        </button>
         <label htmlFor="upload" style={{ display: 'block', marginBottom: '1rem', fontSize: '1rem', fontWeight: 'bold', color: '#ccc' }}>Select an image to upscale:</label>
         <input id="upload" type="file" accept="image/*" onChange={handleFileChange} style={{ marginBottom: '1.5rem' }} />
 

--- a/frontend/src/pages/history.js
+++ b/frontend/src/pages/history.js
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { auth } from '../lib/firebase';
+import { onAuthStateChanged, signOut } from 'firebase/auth';
+
+export default function HistoryPage() {
+  const [user, setUser] = useState(null);
+  const [history, setHistory] = useState([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+      if (currentUser) {
+        await currentUser.reload();
+        if (!currentUser.emailVerified) {
+          alert('Please verify your email before using the app.');
+          await signOut(auth);
+          router.push('/login');
+          return;
+        }
+        setUser(currentUser);
+        loadHistory(currentUser.uid);
+      } else {
+        router.push('/login');
+      }
+    });
+    return () => unsubscribe();
+  }, [router]);
+
+  const loadHistory = async (uid) => {
+    try {
+      const res = await fetch(`/api/history?uid=${uid}`);
+      const data = await res.json();
+      setHistory(data.history || []);
+    } catch (e) {
+      console.error('History load error:', e);
+    }
+  };
+
+  const handleBack = () => {
+    router.push('/app');
+  };
+
+  return (
+    <div style={{ background: '#0d1117', minHeight: '100vh', color: 'white', padding: '2rem' }}>
+      <div style={{ maxWidth: '800px', margin: '0 auto', textAlign: 'center' }}>
+        <h1 style={{ fontSize: '2rem', marginBottom: '1.5rem' }}>Images History</h1>
+        {history.length === 0 ? (
+          <p>No history available.</p>
+        ) : (
+          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+            {history.map((item, idx) => (
+              <div key={idx} style={{ textAlign: 'center' }}>
+                <img src={item.imageUrl} alt={`History ${idx}`} style={{ width: '150px', borderRadius: '6px' }} />
+                <br />
+                <a href={item.imageUrl} download style={{ color: '#3b82f6' }}>
+                  Download
+                </a>
+              </div>
+            ))}
+          </div>
+        )}
+        <button
+          onClick={handleBack}
+          style={{
+            marginTop: '2rem',
+            background: 'linear-gradient(to right, #10b981, #3b82f6)',
+            color: 'white',
+            padding: '0.75rem 1.5rem',
+            borderRadius: '6px',
+            border: 'none',
+            fontWeight: 'bold',
+            fontSize: '1rem',
+            cursor: 'pointer'
+          }}
+        >
+          Back
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/history` page to list user's past images
- link new page from app with an `Images History` button
- document history button in README

## Testing
- `node -e "require('./frontend/src/pages/api/predictions.js');"` *(fails: Cannot find package 'replicate')*

------
https://chatgpt.com/codex/tasks/task_e_6859c6a8791c8322abd63f3b2e9fc569