### PR TITLE
Set replicate output to JPG format

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,7 +24,8 @@ app.post("/api/enhance", upload.single("image"), async (req, res) => {
       {
         version: "dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e",
         input: {
-          image: `data:image/jpeg;base64,${base64Image}`
+          image: `data:image/jpeg;base64,${base64Image}`,
+          output_format: "jpg"
         }
       },
       {

--- a/frontend/src/pages/api/predictions.js
+++ b/frontend/src/pages/api/predictions.js
@@ -30,7 +30,7 @@ export default async function handler(req, res) {
 
     const prediction = await replicate.predictions.create({
       version: 'dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e',
-      input: { image },
+      input: { image, output_format: 'jpg' },
     });
 
     while (prediction.status !== 'succeeded' && prediction.status !== 'failed') {

--- a/frontend/src/pages/api/replicate-run.js
+++ b/frontend/src/pages/api/replicate-run.js
@@ -16,7 +16,7 @@ export default async function handler(req, res) {
     const output = await replicate.run(
       "philz1337x/clarity-upscaler:dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e",
       {
-        input: { image },
+        input: { image, output_format: "jpg" },
       }
     );
 


### PR DESCRIPTION
## Summary
- set `output_format: 'jpg'` when calling the Replicate API in the frontend routes and optional backend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685deb8790308322b478aa1c03ef7bba