### PR TITLE
Limit upload width to 3000px

### DIFF
--- a/frontend/src/pages/app.js
+++ b/frontend/src/pages/app.js
@@ -54,9 +54,23 @@ export default function AppPage() {
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];
-    setSelectedFile(file);
-    setPreviewUrl(URL.createObjectURL(file));
-    setResultUrl(null);
+    if (!file) return;
+
+    const img = new Image();
+    img.onload = () => {
+      if (img.width > 3000) {
+        alert('Maximum allowed image width is 3000px.');
+        e.target.value = null;
+        setSelectedFile(null);
+        setPreviewUrl(null);
+        setResultUrl(null);
+        return;
+      }
+      setSelectedFile(file);
+      setPreviewUrl(URL.createObjectURL(file));
+      setResultUrl(null);
+    };
+    img.src = URL.createObjectURL(file);
   };
 
   const handleEnhance = async () => {


### PR DESCRIPTION
## Summary
- enforce client-side validation for max image width

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685eb83dfcb48322b9dd526ad729db9a