### PR TITLE
Add precise mode

### DIFF
--- a/frontend/src/pages/api/predictions.js
+++ b/frontend/src/pages/api/predictions.js
@@ -13,13 +13,16 @@ const replicate = new Replicate({
 });
 
 const RATE_PER_SECOND = 0.006;
+const PRECISE_COST = 0.15;
+const CREATIVE_VERSION = 'dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e';
+const PRECISE_VERSION = '2fdc3b86a01d338ae89ad58e5d9241398a8a01de9b0dda41ba8a0434c8a00dc3';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { image, uid } = req.body;
+  const { image, uid, mode = 'creative' } = req.body;
 
   if (!image || !uid) {
     return res.status(400).json({ error: 'Missing image or uid' });
@@ -28,11 +31,23 @@ export default async function handler(req, res) {
   try {
     const start = Date.now();
 
-    const prediction = await replicate.predictions.create({
-      version: 'dfad41707589d68ecdccd1dfa600d55a208f9310748e44bfe35b4a6291453d5e',
-      input: { image },
-       input: { image, output_format: 'jpg' },
-    });
+    let prediction;
+    if (mode === 'precise') {
+      prediction = await replicate.predictions.create({
+        version: PRECISE_VERSION,
+        input: {
+          image,
+          enhance_model: 'Low Resolution V2',
+          output_format: 'jpg',
+          upscale_factor: '2x',
+        },
+      });
+    } else {
+      prediction = await replicate.predictions.create({
+        version: CREATIVE_VERSION,
+        input: { image, output_format: 'jpg' },
+      });
+    }
 
     while (prediction.status !== 'succeeded' && prediction.status !== 'failed') {
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -43,9 +58,27 @@ export default async function handler(req, res) {
 
     const end = Date.now();
     const durationSeconds = Math.max((end - start) / 1000, 1); // mínimo 1 segundo
-    const costCharged = parseFloat((durationSeconds * RATE_PER_SECOND).toFixed(2));
+    const costCharged =
+      mode === 'precise'
+        ? PRECISE_COST
+        : parseFloat((durationSeconds * RATE_PER_SECOND).toFixed(2));
 
-    if (prediction.status === 'succeeded' && Array.isArray(prediction.output) && prediction.output[0]) {
+    let outputUrl = null;
+    if (prediction.status === 'succeeded') {
+      if (Array.isArray(prediction.output) && prediction.output[0]) {
+        outputUrl = prediction.output[0];
+      } else if (
+        prediction.output &&
+        typeof prediction.output === 'object' &&
+        prediction.output.image
+      ) {
+        outputUrl = prediction.output.image;
+      } else if (typeof prediction.output === 'string') {
+        outputUrl = prediction.output;
+      }
+    }
+
+    if (prediction.status === 'succeeded' && outputUrl) {
       const userRef = db.collection('users').doc(uid);
       let updatedCredits = 0;
       let updatedFreeUsesLeft = 0;
@@ -85,9 +118,9 @@ export default async function handler(req, res) {
         console.error('Failed to update user credits:', dbErr);
       }
 
-      let storedUrl = prediction.output[0];
+      let storedUrl = outputUrl;
       try {
-        const uploadRes = await cloudinary.uploader.upload(prediction.output[0], {
+        const uploadRes = await cloudinary.uploader.upload(outputUrl, {
           upload_preset: process.env.CLOUDINARY_UPLOAD_PRESET,
         });
         storedUrl = uploadRes.secure_url;

--- a/frontend/src/pages/app.js
+++ b/frontend/src/pages/app.js
@@ -11,6 +11,7 @@ export default function AppPage() {
   const [processing, setProcessing] = useState(false);
   const [credits, setCredits] = useState(0);
   const [freeUsesLeft, setFreeUsesLeft] = useState(0);
+  const [mode, setMode] = useState('creative');
   const [history, setHistory] = useState([]);
   const router = useRouter();
 
@@ -98,7 +99,7 @@ export default function AppPage() {
         const predictionRes = await fetch('/api/predictions', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ image: imageUrl, uid: user.uid }),
+          body: JSON.stringify({ image: imageUrl, uid: user.uid, mode }),
         });
 
         const {
@@ -181,6 +182,22 @@ export default function AppPage() {
         </button>
         <label htmlFor="upload" style={{ display: 'block', marginBottom: '1rem', fontSize: '1rem', fontWeight: 'bold', color: '#ccc' }}>Select an image to upscale:</label>
         <input id="upload" type="file" accept="image/*" onChange={handleFileChange} style={{ marginBottom: '1.5rem' }} />
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '1rem' }}>
+          <span style={{ marginRight: '0.5rem' }}>Creative</span>
+          <label className="switch">
+            <input
+              type="checkbox"
+              checked={mode === 'precise'}
+              onChange={(e) => setMode(e.target.checked ? 'precise' : 'creative')}
+            />
+            <span className="slider"></span>
+          </label>
+          <span style={{ marginLeft: '0.5rem' }}>Precise</span>
+        </div>
+        <p style={{ maxWidth: '600px', margin: '0 auto 1rem', color: '#ccc', fontSize: '0.9rem' }}>
+          Creative mode adds extra details, perfect for renders or digital images. Precise mode improves quality without altering the content, ideal for real photos, faces and landscapes.
+        </p>
 
         {previewUrl && (
           <div style={{ marginBottom: '2rem' }}>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -53,3 +53,48 @@ header {
   animation: spin 1s linear infinite;
   margin-left: 0.5rem;
 }
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 24px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+  background-color: #10b981;
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(26px);
+}


### PR DESCRIPTION
## Summary
- support two upscaling modes: creative and precise
- compute fixed pricing for precise mode
- allow users to toggle modes in app UI
- style new switch component

## Testing
- `npm install --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_685ec7b8077c8322888ff5ffed61ab4a