### PR TITLE
Limit precise mode uploads to 4MB

### DIFF
--- a/frontend/src/pages/app.js
+++ b/frontend/src/pages/app.js
@@ -76,7 +76,7 @@ export default function AppPage() {
 
   const handleEnhance = async () => {
     if (!selectedFile) return;
-    if (mode === 'precise' && selectedFile.size > 4 * 1024 * 1024) {
+    if (mode === 'precise' && selectedFile.size > 3 * 1024 * 1024) {
       alert('The maximum size in this mode is 4MB. Please reduce your file size to proceed.');
       return;
     }

--- a/frontend/src/pages/app.js
+++ b/frontend/src/pages/app.js
@@ -77,7 +77,7 @@ export default function AppPage() {
   const handleEnhance = async () => {
     if (!selectedFile) return;
     if (mode === 'precise' && selectedFile.size > 3 * 1024 * 1024) {
-      alert('The maximum size in this mode is 4MB. Please reduce your file size to proceed.');
+      alert('The maximum size in this mode is 3MB. Please reduce your file size to proceed.');
       return;
     }
     if (credits <= 0 && freeUsesLeft <= 0) {

--- a/frontend/src/pages/app.js
+++ b/frontend/src/pages/app.js
@@ -76,6 +76,10 @@ export default function AppPage() {
 
   const handleEnhance = async () => {
     if (!selectedFile) return;
+    if (mode === 'precise' && selectedFile.size > 4 * 1024 * 1024) {
+      alert('The maximum size in this mode is 4MB. Please reduce your file size to proceed.');
+      return;
+    }
     if (credits <= 0 && freeUsesLeft <= 0) {
       alert('You have no credits or free uses left. Please recharge.');
       return;


### PR DESCRIPTION
## Summary
- limit image size in precise mode in `handleEnhance`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685f0bb281148322b9636039311888da