### PR TITLE
Limit free credits for new users to one

### DIFF
--- a/frontend/src/pages/api/credit-user.js
+++ b/frontend/src/pages/api/credit-user.js
@@ -16,8 +16,8 @@ export default async function handler(req, res) {
     const userSnap = await userRef.get();
 
     if (!userSnap.exists) {
-      // Nuevo → se crea con los créditos comprados + los 3 usos gratis
-      await userRef.set({ credits: parseFloat(amount), freeUsesLeft: 3 });
+      // Nuevo → se crea con los créditos comprados + 1 uso gratis
+      await userRef.set({ credits: parseFloat(amount), freeUsesLeft: 1 });
     } else {
       const current = userSnap.data();
       const updatedCredits = (current.credits || 0) + parseFloat(amount);

--- a/frontend/src/pages/api/credits.js
+++ b/frontend/src/pages/api/credits.js
@@ -13,7 +13,7 @@ export default async function handler(req, res) {
     const userSnap = await userRef.get();
 
     if (!userSnap.exists) {
-      const initialData = { credits: 0, freeUsesLeft: 1 };
+      const initialData = { credits: 0, freeUsesLeft: 0 };
       await userRef.set(initialData);
       return res.status(200).json(initialData);
     }

--- a/frontend/src/pages/api/credits.js
+++ b/frontend/src/pages/api/credits.js
@@ -13,7 +13,7 @@ export default async function handler(req, res) {
     const userSnap = await userRef.get();
 
     if (!userSnap.exists) {
-      const initialData = { credits: 0, freeUsesLeft: 3 };
+      const initialData = { credits: 0, freeUsesLeft: 1 };
       await userRef.set(initialData);
       return res.status(200).json(initialData);
     }

--- a/frontend/src/pages/api/predictions.js
+++ b/frontend/src/pages/api/predictions.js
@@ -88,7 +88,7 @@ export default async function handler(req, res) {
 
         if (!snap.exists) {
           updatedCredits = 0;
-          updatedFreeUsesLeft = 1;
+          updatedFreeUsesLeft = 0;
           await userRef.set({ credits: updatedCredits, freeUsesLeft: updatedFreeUsesLeft });
         } else {
           const data = snap.data();

--- a/frontend/src/pages/api/predictions.js
+++ b/frontend/src/pages/api/predictions.js
@@ -88,7 +88,7 @@ export default async function handler(req, res) {
 
         if (!snap.exists) {
           updatedCredits = 0;
-          updatedFreeUsesLeft = 3;
+          updatedFreeUsesLeft = 1;
           await userRef.set({ credits: updatedCredits, freeUsesLeft: updatedFreeUsesLeft });
         } else {
           const data = snap.data();

--- a/frontend/src/pages/api/webhook.js
+++ b/frontend/src/pages/api/webhook.js
@@ -39,7 +39,7 @@ export default async function handler(req, res) {
         const userRef = db.collection('users').doc(uid);
         const snap = await userRef.get();
         if (!snap.exists) {
-          await userRef.set({ credits: 5.0, freeUsesLeft: 3 });
+          await userRef.set({ credits: 5.0, freeUsesLeft: 1 });
         } else {
           const current = snap.data();
           const updatedCredits = (current.credits || 0) + 5.0;


### PR DESCRIPTION
## Summary
- update default `freeUsesLeft` from 3 to 1 across API routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862ae4a27a483228912281138d2702a